### PR TITLE
Fix backslash bug on qemu

### DIFF
--- a/src/bare-metal/monitor.c
+++ b/src/bare-metal/monitor.c
@@ -582,8 +582,8 @@ beginning:
 		char c = getchar();
 
 		switch ((uint8_t)c) {
-		case 0x08:
-		case 0x7f: /* backspace */
+		case 0x08: /* backspace */
+		case 0x7f:
 			if (cursor) {
 				cursor--;
 				putstr("\10 \10");


### PR DESCRIPTION
On QEMU serial console, backslash return a 0x08 char