### PR TITLE
Allow to comment command line

### DIFF
--- a/src/bare-metal/monitor.c
+++ b/src/bare-metal/monitor.c
@@ -631,6 +631,10 @@ static size_t tokenize_line(char *line, char **argv, size_t argv_length)
 
 	for (char *p = line; *p && argv_index < argv_length; p++) {
 		char c = *p;
+		
+		/* Find the beginning of a comment, ignore all word after */
+		if(c == '#')
+			break;
 
 		switch (state) {
 		case IDLE:


### PR DESCRIPTION
Allow to comment a command line after command arguments.

Example of `bootstrap.txt` :
```
# Test alias memory
echo Run test...
ww 2000 1 2 3 4 5 6 7 8    # write a test pattern into RAM
rw 2000 16                 # read it back
rw 08002000 16             # same content at 128 MiB
rw 0c002000 16             # not at 192 MiB
rw 10002000 16             # same at 256 MiB
rw 20002000 16

# Load and run Linux
echo Loading Linux...
cw   40b80000 8000 0x120000
call 8000 0 0xffffffff 0
```